### PR TITLE
풀리퀘 맥OS 바이너리 배포 절차 진행 테스트

### DIFF
--- a/.github/workflows/pyinstaller-mac-compile.yml
+++ b/.github/workflows/pyinstaller-mac-compile.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-11
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pyinstaller-mac-compile.yml
+++ b/.github/workflows/pyinstaller-mac-compile.yml
@@ -1,0 +1,38 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: pyinstaller-mac-compile
+
+on:
+  push:
+    branches: [ dist ]
+  pull_request:
+    branches: [ dist ]
+
+jobs:
+  build:
+
+    runs-on: macos-11
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pyinstaller
+        pip install -r requirements.txt
+    - name: build exe file
+      run: |
+        pyinstaller --onefile qtmain.py
+    - name: commit and push
+      run: |
+        git config --global user.name 'binchoo'
+        git config --global user.email 'jbinchoo@gmail.com'
+        git add dist
+        git commit -m "Build windows binary."
+        git push


### PR DESCRIPTION
## 배포 정책

1. master에 소스 코드 커밋
2. 커밋에 태그를 붙이고 릴리스
3. dist 브랜치로 풀리퀘 생성
4. actions가 윈도우와 맥용 바이너리를 생성
5. dist 브랜치 /dist 폴더에 커밋해 줌
6. 본인은 해당 바이너리를 다운로드하여 릴리스에 추가해줌.